### PR TITLE
A2DP check removed and connection retry added with for-loop

### DIFF
--- a/src/bt-reload-headphones
+++ b/src/bt-reload-headphones
@@ -2,8 +2,6 @@
 CONFIG=/etc/bt-reload-headphones.conf
 
 reconnect_device() {
-    bluetoothctl --timeout 5 disconnect $1
-    sleep 1
     bluetoothctl --timeout 10 connect $1
 }
 
@@ -70,7 +68,7 @@ should_reconnect() {
     if [ $? -eq 0 ] ; then
         return 1
     fi
-    is_headset $1 && ! can_set_a2dp $1
+    is_headset $1
 }
 
 if [ ! -e "$CONFIG" ] ; then
@@ -86,5 +84,7 @@ fi
 MACS=$(bluetoothctl devices | awk '{print $2}')
 
 for MAC in $MACS ; do
-    should_reconnect $MAC && reconnect_device $MAC
+    for COUNT in {1..10} ; do
+        should_reconnect $MAC && reconnect_device $MAC
+    done
 done


### PR DESCRIPTION
Hi.

Your package was useful to me. Thanks!.

The purpose of this pull request is to propose the simplification. In my case, the headphone connected in HSP / HFP, instead of A2DP. Removing the A2DP check resolved this issue.
The for-loop has been included to make more connection attempts. If the device connects on the first attempt, the other attempts will only fail. Another alternative is to try to detect if the headphone is an audio output and interrupt the for loop.
Parts of the script that are not used can be deleted. I have not yet done so in order to discuss these changes.